### PR TITLE
Returning log prob of accepted samples

### DIFF
--- a/affine/affine.py
+++ b/affine/affine.py
@@ -1,14 +1,13 @@
 import torch
 from tqdm import tqdm
 
-def sample(log_prob, n_params, n_walkers, n_steps, walkers, progress=True, save_lp=False):
+def sample(log_prob, n_params, n_walkers, n_steps, walkers1, walkers2, progress=True, save_lp=False):
 
     # Progress-bar
     if progress:
         pbar = tqdm(total=n_steps, desc="Sampling")  # Jupyter notebook or qtconsole
 
     # Initialize current state
-    walkers1, walkers2 = walkers
     current_state1 = torch.as_tensor(walkers1)
     current_state2 = torch.as_tensor(walkers2)
 
@@ -118,7 +117,7 @@ def sample(log_prob, n_params, n_walkers, n_steps, walkers, progress=True, save_
         # Chain = np.unique(chain, axis=0) # this may need to be here,
         return chain
 
-def sample_batch(log_prob, n_steps, n_burnin, current_state, thin=1, args=[], progressbar=True, savelp=False, device="cpu"):
+def sample_batch(log_prob, n_steps, current_state, n_burnin=0, thin=1, args=[], progress=True, save_lp=False, device="cpu"):
     # Split the current state
     current_state1, current_state2 = current_state
 
@@ -133,11 +132,11 @@ def sample_batch(log_prob, n_steps, n_burnin, current_state, thin=1, args=[], pr
 
     # Holder for the whole chain
     chain = torch.zeros((int((n_steps-n_burnin)/thin), n_walkers*2, n_batch, n_params), device=device)
-    if savelp is True:
+    if save_lp is True:
         lpchain = torch.zeros((int((n_steps-n_burnin)/thin), n_walkers*2, n_batch), device=device)
 
     # Progress bar?
-    loop = tqdm(range(1, n_steps)) if progressbar else range(1, n_steps)
+    loop = tqdm(range(1, n_steps)) if progress else range(1, n_steps)
 
     # counter variable
     counter = 0
@@ -189,12 +188,12 @@ def sample_batch(log_prob, n_steps, n_burnin, current_state, thin=1, args=[], pr
         # Append to chain if we're past burnin
         if epoch >= n_burnin and epoch%thin == (thin-1):
             chain[counter] = torch.unsqueeze(torch.cat([current_state1, current_state2], dim=0), dim=0)
-            if savelp is True:
+            if save_lp is True:
                 lpchain[counter] = torch.unsqueeze(torch.cat([logp_current1, logp_current2], dim=0), dim=0)
             counter += 1
 
     # Stack up the chain and return
-    if savelp is True:
+    if save_lp is True:
         return chain, lpchain
     else:
         return chain

--- a/affine/affine.py
+++ b/affine/affine.py
@@ -1,12 +1,14 @@
 import torch
 from tqdm import tqdm
 
-def sample(log_prob, n_params, n_walkers, n_steps, walkers1, walkers2):
+def sample(log_prob, n_params, n_walkers, n_steps, walkers, progress=True, save_lp=False):
 
     # Progress-bar
-    pbar = tqdm(total=n_steps, desc="Sampling")  # Jupyter notebook or qtconsole
+    if progress:
+        pbar = tqdm(total=n_steps, desc="Sampling")  # Jupyter notebook or qtconsole
 
     # Initialize current state
+    walkers1, walkers2 = walkers
     current_state1 = torch.as_tensor(walkers1)
     current_state2 = torch.as_tensor(walkers2)
 
@@ -17,6 +19,7 @@ def sample(log_prob, n_params, n_walkers, n_steps, walkers1, walkers2):
     logp_current1 = torch.as_tensor(logp_current1)
     logp_current2 = torch.as_tensor(logp_current2)
 
+    # sort out any nans
     logp_current1 = torch.where(
         torch.isnan(logp_current1),
         torch.ones_like(logp_current1).fill_(float("inf")),
@@ -28,14 +31,16 @@ def sample(log_prob, n_params, n_walkers, n_steps, walkers1, walkers2):
 
     # Holder for the whole chain
     chain = [torch.cat([current_state1, current_state2], axis=0)]
+    if save_lp is True:
+        lp_chain = [torch.cat([logp_current1, logp_current2], axis=0)]
 
 
     # MCMC loop
     for epoch in range(1, n_steps):
 
         # FIRST SET OF WALKERS:
+
         # Proposals
-        #idx1 = torch.as_tensor(np.random.randint(0, n_walkers, n_walkers))
         idx1 = torch.randint(low=0, high=n_walkers, size=(n_walkers,))
         partners1 = current_state2[idx1]
         z1 = 0.5 * (torch.rand((n_walkers,)) + 1) ** 2
@@ -64,8 +69,8 @@ def sample(log_prob, n_params, n_walkers, n_steps, walkers1, walkers2):
         logp_current1 = torch.where(accept1_, logp_proposed1, logp_current1)
 
         # SECOND SET OF WALKERS:
+
         # Proposals
-        #idx2 = torch.as_tensor(np.random.randint(0, n_walkers, n_walkers))
         idx2 = torch.randint(low=0, high=n_walkers, size=(n_walkers,))
         partners2 = current_state1[idx2]
         z2 = 0.5 * (torch.rand((n_walkers,)) + 1) ** 2
@@ -95,18 +100,25 @@ def sample(log_prob, n_params, n_walkers, n_steps, walkers1, walkers2):
 
         # Append to chain
         chain.append(torch.cat([current_state1, current_state2], axis=0))
+        if save_lp is True:
+            lp_chain.append(torch.cat([logp_current1, logp_current2], axis=0))
 
         # Update the progressbar
-        pbar.update(1)
+        if progress:
+            pbar.update(1)
 
     # Stack up the chain
     chain = torch.stack(chain, axis=0)
+    if save_lp is True:
+        lp_chain = torch.stack(lp_chain, axis=0)
 
-    # Chain = np.unique(chain, axis=0) # this may need to be here,
-    return chain[1:, :, :]
+    if save_lp is True:
+        return chain, lp_chain
+    else:
+        # Chain = np.unique(chain, axis=0) # this may need to be here,
+        return chain
 
-# state variables have shape: (n_walkers, n_batch, n_params)
-def sample_batch(log_prob, n_steps, current_state, args=[], progressbar=True):
+def sample_batch(log_prob, n_steps, n_burnin, current_state, thin=1, args=[], progressbar=True, savelp=False, device="cpu"):
     # Split the current state
     current_state1, current_state2 = current_state
 
@@ -120,17 +132,22 @@ def sample_batch(log_prob, n_steps, current_state, args=[], progressbar=True):
     logp_current2[torch.isnan(logp_current2)] = -float('inf')
 
     # Holder for the whole chain
-    chain = [torch.unsqueeze(torch.cat([current_state1, current_state2], dim=0), dim=0)]
+    chain = torch.zeros((int((n_steps-n_burnin)/thin), n_walkers*2, n_batch, n_params), device=device)
+    if savelp is True:
+        lpchain = torch.zeros((int((n_steps-n_burnin)/thin), n_walkers*2, n_batch), device=device)
 
     # Progress bar?
     loop = tqdm(range(1, n_steps)) if progressbar else range(1, n_steps)
+
+    # counter variable
+    counter = 0
 
     # MCMC loop
     for epoch in loop:
         # First set of walkers:
         # Proposals
-        partners1 = current_state2[np.random.randint(0, n_walkers, n_walkers)]
-        z1 = 0.5 * (torch.rand(n_walkers, n_batch) + 1) ** 2
+        partners1 = current_state2[torch.randint(0, n_walkers, (n_walkers,))]
+        z1 = 0.5 * (torch.rand(n_walkers, n_batch, device=device) + 1) ** 2
         proposed_state1 = partners1 + (z1 * (current_state1 - partners1).permute(2, 0, 1)).permute(1, 2, 0)
 
         # Target log prob at proposed points
@@ -138,10 +155,10 @@ def sample_batch(log_prob, n_steps, current_state, args=[], progressbar=True):
         logp_proposed1[torch.isnan(logp_proposed1)] = -float('inf')
 
         # Acceptance probability
-        p_accept1 = torch.minimum(torch.ones([n_walkers, n_batch]), z1**(n_params-1) * torch.exp(logp_proposed1 - logp_current1))
+        p_accept1 = torch.minimum(torch.ones([n_walkers, n_batch], device=device), z1**(n_params-1) * torch.exp(logp_proposed1 - logp_current1))
 
         # Accept or not
-        accept1_ = (torch.rand([n_walkers, n_batch]) <= p_accept1)
+        accept1_ = (torch.rand([n_walkers, n_batch], device=device) <= p_accept1)
         accept1 = accept1_.type(torch.float32)
 
         # Update the state
@@ -150,8 +167,8 @@ def sample_batch(log_prob, n_steps, current_state, args=[], progressbar=True):
 
         # Second set of walkers:
         # Proposals
-        partners2 = current_state1[np.random.randint(0, n_walkers, n_walkers)]
-        z2 = 0.5 * (torch.rand(n_walkers, n_batch) + 1) ** 2
+        partners2 = current_state1[torch.randint(0, n_walkers, (n_walkers,))]
+        z2 = 0.5 * (torch.rand(n_walkers, n_batch, device=device) + 1) ** 2
         proposed_state2 = partners2 + (z2 * (current_state2 - partners2).permute(2, 0, 1)).permute(1, 2, 0)
 
         # Target log prob at proposed points
@@ -159,18 +176,25 @@ def sample_batch(log_prob, n_steps, current_state, args=[], progressbar=True):
         logp_proposed2[torch.isnan(logp_proposed2)] = -float('inf')
 
         # Acceptance probability
-        p_accept2 = torch.minimum(torch.ones([n_walkers, n_batch]), z2**(n_params-1) * torch.exp(logp_proposed2 - logp_current2))
+        p_accept2 = torch.minimum(torch.ones([n_walkers, n_batch], device=device), z2**(n_params-1) * torch.exp(logp_proposed2 - logp_current2))
 
         # Accept or not
-        accept2_ = (torch.rand([n_walkers, n_batch]) <= p_accept2)
+        accept2_ = (torch.rand([n_walkers, n_batch], device=device) <= p_accept2)
         accept2 = accept2_.type(torch.float32)
 
         # Update the state
         current_state2 = (current_state2.permute(2, 0, 1) * (1 - accept2) + proposed_state2.permute(2, 0, 1) * accept2).permute(1, 2, 0)
         logp_current2[accept2_.bool()] = logp_proposed2[accept2_.bool()]
 
-        # Append to chain
-        chain.append(torch.unsqueeze(torch.cat([current_state1, current_state2], dim=0), dim=0))
+        # Append to chain if we're past burnin
+        if epoch >= n_burnin and epoch%thin == (thin-1):
+            chain[counter] = torch.unsqueeze(torch.cat([current_state1, current_state2], dim=0), dim=0)
+            if savelp is True:
+                lpchain[counter] = torch.unsqueeze(torch.cat([logp_current1, logp_current2], dim=0), dim=0)
+            counter += 1
 
     # Stack up the chain and return
-    return torch.cat(chain, dim=0)
+    if savelp is True:
+        return chain, lpchain
+    else:
+        return chain


### PR DESCRIPTION
This was a feature requested by @anikhalder and @AlexBrown6291. Adds an option to save the log prob of the accepted MCMC samples. Also incorporates a couple of other things from the pop-cosmos version of affine (some device stuff, burnin, thinning).

Should await confirmation from @anikhalder and @AlexBrown6291 before merging (they will respectively be testing the `sample_batch` and `sample` functions).